### PR TITLE
remove font size calc to align button text

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -25,7 +25,7 @@ const Button = ({
           <Loading />
         </div>
       ) : (
-        <div style={{ fontSize: "calc(12px + 0.4vw)" }}>{children}</div>
+        <div>{children}</div>
       )}
     </button>
     {undertext ? <div className="undertext">{undertext}</div> : null}


### PR DESCRIPTION
Without this text size calculation, the text is better aligned when responding to different screen sizes.